### PR TITLE
Suppress `CompositeFormat` warning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 		<LangVersion>12.0</LangVersion>
 		
 		<!-- NuGet -->
-		<Version>2.0.15</Version>
+		<Version>2.0.16</Version>
 		<AssemblyVersion>2.0.0</AssemblyVersion>
 		<FileVersion>2.0.0</FileVersion>
 		<Authors>Jon Sagara</Authors>

--- a/src/Sagara.Core/Extensions/IEnumerableExtensions.cs
+++ b/src/Sagara.Core/Extensions/IEnumerableExtensions.cs
@@ -7,7 +7,7 @@ public static class IEnumerableExtensions
     /// Returns an enumerable that incorporates the element's index into a tuple.
     /// </summary>
     /// <remarks>
-    /// NOTE: This will be built into .NET 9 and above, so this method is for .NET 8 and below.
+    /// NOTE: This will be built into .NET 9 and above, so this method is for .NET 8.
     /// </remarks>
     /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
     /// <param name="source">The source enumerable providing the elements.</param>

--- a/src/Sagara.Core/Validation/ValidationHelper.cs
+++ b/src/Sagara.Core/Validation/ValidationHelper.cs
@@ -18,7 +18,10 @@ public static class ValidationHelper
 
         if (string.IsNullOrWhiteSpace(property.Value))
         {
+            // Justification: can't use composite format; we're loading a localized string from a resource file.
+#pragma warning disable CA1863 // Use 'CompositeFormat'
             errors.Add(new RequestError(property.PropertyName, string.Format(CultureInfo.CurrentCulture, VHR.RequiredField, property.GetDisplayName())));
+#pragma warning restore CA1863 // Use 'CompositeFormat'
         }
     }
 
@@ -33,7 +36,10 @@ public static class ValidationHelper
 
         if (property.Value is null)
         {
+            // Justification: can't use composite format; we're loading a localized string from a resource file.
+#pragma warning disable CA1863 // Use 'CompositeFormat'
             errors.Add(new RequestError(property.PropertyName, string.Format(CultureInfo.CurrentCulture, VHR.RequiredField, property.GetDisplayName())));
+#pragma warning restore CA1863 // Use 'CompositeFormat'
         }
     }
 
@@ -48,7 +54,10 @@ public static class ValidationHelper
 
         if (property.Value is null)
         {
+            // Justification: can't use composite format; we're loading a localized string from a resource file.
+#pragma warning disable CA1863 // Use 'CompositeFormat'
             errors.Add(new RequestError(property.PropertyName, string.Format(CultureInfo.CurrentCulture, VHR.RequiredField, property.GetDisplayName())));
+#pragma warning restore CA1863 // Use 'CompositeFormat'
         }
     }
 
@@ -61,7 +70,10 @@ public static class ValidationHelper
 
         if (property.Value?.Length > maxLength)
         {
+            // Justification: can't use composite format; we're loading a localized string from a resource file.
+#pragma warning disable CA1863 // Use 'CompositeFormat'
             errors.Add(new RequestError(property.PropertyName, string.Format(CultureInfo.CurrentCulture, VHR.StringMaxLength, property.GetDisplayName(), maxLength)));
+#pragma warning restore CA1863 // Use 'CompositeFormat'
         }
     }
 
@@ -74,7 +86,10 @@ public static class ValidationHelper
 
         if (property.Value?.Length < minLength)
         {
+            // Justification: can't use composite format; we're loading a localized string from a resource file.
+#pragma warning disable CA1863 // Use 'CompositeFormat'
             errors.Add(new RequestError(property.PropertyName, string.Format(CultureInfo.CurrentCulture, VHR.StringMinLength, property.GetDisplayName(), minLength)));
+#pragma warning restore CA1863 // Use 'CompositeFormat'
         }
     }
 

--- a/src/Sagara.Core/docs/Sagara.Core.IEnumerableExtensions.md
+++ b/src/Sagara.Core/docs/Sagara.Core.IEnumerableExtensions.md
@@ -38,4 +38,4 @@ The source enumerable providing the elements.
 [System.Collections.Generic.IEnumerable&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.Generic.IEnumerable-1 'System.Collections.Generic.IEnumerable`1')[&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple 'System.ValueTuple')[System.Int32](https://docs.microsoft.com/en-us/dotnet/api/System.Int32 'System.Int32')[,](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple 'System.ValueTuple')[TSource](Sagara.Core.IEnumerableExtensions.md#Sagara.Core.IEnumerableExtensions.Index_TSource_(thisSystem.Collections.Generic.IEnumerable_TSource_).TSource 'Sagara.Core.IEnumerableExtensions.Index<TSource>(this System.Collections.Generic.IEnumerable<TSource>).TSource')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple 'System.ValueTuple')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.Generic.IEnumerable-1 'System.Collections.Generic.IEnumerable`1')
 
 ### Remarks
-NOTE: This will be built into .NET 9 and above, so this method is for .NET 8 and below.
+NOTE: This will be built into .NET 9 and above, so this method is for .NET 8.


### PR DESCRIPTION
We're loading localized strings from a resource file, and these can't be easily cached as a `CompositeFormat`.