### PR TITLE
Update the minimum version of Microsoft.IO.RecyclableMemoryStream to 3.0.1 to get an inifinite loop bug fix.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 		<LangVersion>12.0</LangVersion>
 		
 		<!-- NuGet -->
-		<Version>2.0.17</Version>
+		<Version>2.0.18</Version>
 		<AssemblyVersion>2.0.0</AssemblyVersion>
 		<FileVersion>2.0.0</FileVersion>
 		<Authors>Jon Sagara</Authors>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.301",
+    "version": "8.0.302",
     "rollForward": "latestPatch"
   }
 }

--- a/src/Sagara.Core/Sagara.Core.csproj
+++ b/src/Sagara.Core/Sagara.Core.csproj
@@ -29,7 +29,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
+		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
 		<PackageReference Include="NodaTime" Version="3.1.11" />
 	</ItemGroup>
 


### PR DESCRIPTION
See: https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/releases/tag/v3.0.1