### PR TITLE
chore: Upgraded to .NET SDK 10.0.202 and .NET 10.0.6.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,9 +4,9 @@
 		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		
 		<!-- NuGet -->
-		<Version>5.3.7</Version>
-		<AssemblyVersion>5.3.0</AssemblyVersion>
-		<FileVersion>5.3.0</FileVersion>
+		<Version>5.4.0</Version>
+		<AssemblyVersion>5.4.0</AssemblyVersion>
+		<FileVersion>5.4.0</FileVersion>
 		<Authors>Jon Sagara</Authors>
 		<Copyright>Copyright 2022-2026</Copyright>
 		<RepositoryUrl>https://github.com/jonsagara/Sagara.Core</RepositoryUrl>

--- a/src/Sagara.Core.Caching/Sagara.Core.Caching.csproj
+++ b/src/Sagara.Core.Caching/Sagara.Core.Caching.csproj
@@ -29,13 +29,13 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.14" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.14" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.15" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.15" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Sagara.Core.Data/Sagara.Core.Data.csproj
+++ b/src/Sagara.Core.Data/Sagara.Core.Data.csproj
@@ -30,13 +30,13 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.14" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.14" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.15" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.15" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Sagara.Core.Logging.Serilog/Sagara.Core.Logging.Serilog.csproj
+++ b/src/Sagara.Core.Logging.Serilog/Sagara.Core.Logging.Serilog.csproj
@@ -32,12 +32,12 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.14" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.15" />
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
 	</ItemGroup>
 

--- a/src/Sagara.Core/Sagara.Core.csproj
+++ b/src/Sagara.Core/Sagara.Core.csproj
@@ -31,7 +31,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.6" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
@@ -39,17 +39,17 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.14" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.14" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.14" />
-		<PackageReference Include="System.Text.Json" Version="9.0.14" NoWarn="NU1510" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.15" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.15" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.15" />
+		<PackageReference Include="System.Text.Json" Version="9.0.15" NoWarn="NU1510" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
-		<PackageReference Include="System.Text.Json" Version="10.0.5" NoWarn="NU1510" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
+		<PackageReference Include="System.Text.Json" Version="10.0.6" NoWarn="NU1510" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Bump version numbers for multiple packages to latest stable releases.
- Ensure compatibility with .NET 9.0 and 10.0 frameworks.